### PR TITLE
Initializes the symbolizer in hello_main.cc

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -49,6 +49,7 @@ cc_test(
     deps = [
         ":hello",
         "@com_google_absl//absl/debugging:failure_signal_handler",
+        "@com_google_absl//absl/debugging:symbolize",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
     ],

--- a/test/hello_main.cc
+++ b/test/hello_main.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "absl/debugging/failure_signal_handler.h"
+#include "absl/debugging/symbolize.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "hello.h"
 
 int main(int argc, const char** argv) {
+  absl::InitializeSymbolizer(argv[0]);
   absl::InstallFailureSignalHandler(absl::FailureSignalHandlerOptions());
 
   std::string greeting = hello::Greet(argc < 2 ? "world" : argv[1]);


### PR DESCRIPTION
This makes for a complete example on how to properly
use Abseil's failure signal handler.