### PR TITLE
Add gRPC to the federation

### DIFF
--- a/ci/automerge_pr.sh
+++ b/ci/automerge_pr.sh
@@ -103,6 +103,7 @@ for std in ${STD}; do
     @com_google_absl//absl/...:all \
     @com_google_googletest//googletest/...:all \
     @com_github_google_benchmark//test/...:all \
+    @com_github_grpc_grpc//test/cpp/common/...:all \
     -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
     -@com_google_absl//absl/time/internal/cctz:time_zone_lookup_test \
     ${OTHER_TESTS}
@@ -138,6 +139,7 @@ for std in ${STD}; do
     @com_google_absl//absl/...:all \
     @com_google_googletest//googletest/...:all \
     @com_github_google_benchmark//test/...:all \
+    @com_github_grpc_grpc//test/cpp/common/...:all \
     -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
     -@com_google_absl//absl/time/internal/cctz:time_zone_lookup_test \
     ${OTHER_TESTS}

--- a/head_sync.py
+++ b/head_sync.py
@@ -59,6 +59,7 @@ PROJECTS = [
     GitHubProject('com_google_googletest', 'google', 'googletest'),
     GitHubProject('com_github_google_benchmark', 'google', 'benchmark'),
     GitHubProject('com_github_google_tcmalloc', 'google', 'tcmalloc'),
+    GitHubProject('com_github_grpc_grpc', 'grpc', 'grpc'),
 ]
 
 


### PR DESCRIPTION
Let's try this out. Since gRPC has many dependencies, it may have to add more transitive dependencies. gRPC has following dependencies;

- https://github.com/abseil/abseil-cpp
- https://github.com/c-ares/c-ares
- https://github.com/census-instrumentation/opencensus-cpp
- https://github.com/envoyproxy/data-plane-api
- https://github.com/gflags/gflags
- https://github.com/google/benchmark
- https://github.com/google/boringssl
- https://github.com/google/googletest
- https://github.com/google/protobuf
- https://github.com/libuv/libuv
- https://github.com/madler/zlib
- https://github.com/protocolbuffers/upb
- https://github.com/twisted/constantly
- https://github.com/twisted/incremental
- https://github.com/twisted/twisted
- https://github.com/yaml/pyyaml
- https://github.com/zopefoundation/zope.interface

gRPC has tons of tests but only `//test/cpp/common/...:all` is added to the script because others are spending too much time and sometime flaky.