### PR TITLE
Add bazelbuild/rules_fuzzing to federation deps.

### DIFF
--- a/ci/automerge_pr.sh
+++ b/ci/automerge_pr.sh
@@ -22,8 +22,8 @@ set -euox pipefail
 
 BUILD_ROOT="$(realpath $(dirname ${0})/..)"
 
-readonly GCC_DOCKER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20200909"
-readonly CLANG_DOCKER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20200909"
+readonly GCC_DOCKER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20210525"
+readonly CLANG_DOCKER="gcr.io/google.com/absl-177019/linux_hybrid-latest:20210525"
 
 ################################### START TESTS ################################
 
@@ -46,6 +46,7 @@ for std in ${STD}; do
   "${GCC_DOCKER}" \
   /usr/local/bin/bazel test ... \
     --copt=-Werror \
+    --distdir="/bazel-distdir" \
     --keep_going \
     --show_timestamps \
     --test_output=errors
@@ -69,6 +70,7 @@ for std in ${STD}; do
   /usr/local/bin/bazel test ... \
     --copt="--gcc-toolchain=/usr/local" \
     --copt=-Werror \
+    --distdir="/bazel-distdir" \
     --keep_going \
     --linkopt="--gcc-toolchain=/usr/local" \
     --show_timestamps \
@@ -82,7 +84,7 @@ for std in ${STD}; do
 
   if [ "${std}" = "c++17" ]; then
     # As of 2020-02-28, TCMalloc requires C++17.
-    OTHER_TESTS="@com_github_google_tcmalloc//tcmalloc/...:all"
+    OTHER_TESTS="@com_github_google_tcmalloc//tcmalloc/..."
   else
     OTHER_TESTS=""
   fi
@@ -97,14 +99,16 @@ for std in ${STD}; do
   "${GCC_DOCKER}" \
   /usr/local/bin/bazel test \
     --define absl=1 \
+    --distdir="/bazel-distdir" \
+    --build_tag_filters=-manual \
     --test_tag_filters=-benchmark,-no_federation_test \
     --keep_going \
     --show_timestamps \
     --test_output=errors \
     -- \
-    @com_google_absl//absl/...:all \
-    @com_google_googletest//googletest/...:all \
-    @com_github_google_benchmark//test/...:all \
+    @com_google_absl//absl/... \
+    @com_google_googletest//googletest/... \
+    @com_github_google_benchmark//test/... \
     -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
     -@com_google_absl//absl/time/internal/cctz:time_zone_lookup_test \
     ${OTHER_TESTS}
@@ -116,7 +120,7 @@ for std in ${STD}; do
 
   if [ "${std}" = "c++17" ]; then
     # As of 2020-02-28, TCMalloc requires C++17.
-    OTHER_TESTS="@com_github_google_tcmalloc//tcmalloc/...:all"
+    OTHER_TESTS="@com_github_google_tcmalloc//tcmalloc/..."
   else
     OTHER_TESTS=""
   fi
@@ -132,6 +136,7 @@ for std in ${STD}; do
   "${CLANG_DOCKER}" \
   /usr/local/bin/bazel test \
     --copt="--gcc-toolchain=/usr/local" \
+    --distdir="/bazel-distdir" \
     --define absl=1 \
     --test_tag_filters=-benchmark,-no_federation_test \
     --keep_going \
@@ -139,9 +144,9 @@ for std in ${STD}; do
     --show_timestamps \
     --test_output=errors \
     -- \
-    @com_google_absl//absl/...:all \
-    @com_google_googletest//googletest/...:all \
-    @com_github_google_benchmark//test/...:all \
+    @com_google_absl//absl/... \
+    @com_google_googletest//googletest/... \
+    @com_github_google_benchmark//test/... \
     -@com_google_absl//absl/time/internal/cctz:time_zone_format_test \
     -@com_google_absl//absl/time/internal/cctz:time_zone_lookup_test \
     ${OTHER_TESTS}

--- a/ci/automerge_pr.sh
+++ b/ci/automerge_pr.sh
@@ -100,7 +100,6 @@ for std in ${STD}; do
   /usr/local/bin/bazel test \
     --define absl=1 \
     --distdir="/bazel-distdir" \
-    --build_tag_filters=-manual \
     --test_tag_filters=-benchmark,-no_federation_test \
     --keep_going \
     --show_timestamps \

--- a/federation_deps.bzl
+++ b/federation_deps.bzl
@@ -15,18 +15,6 @@ def federation_deps():
       sha256 = "1e19e9a3bc3d4ee91d7fcad00653485ee6c798efbbf9588d40b34cbfbded143d",
     )
 
-    # ********** rules_fuzzing *****************
-    http_archive(
-      name = "rules_fuzzing",  # 2021-05-19T01:47:21Z
-      urls = [
-           # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/bazelbuild/rules_fuzzing/archive/a8e8945bebf4f2a4618b27f127f9fc7009afacff.zip",
-           "https://github.com/bazelbuild/rules_fuzzing/archive/a8e8945bebf4f2a4618b27f127f9fc7009afacff.zip"
-      ],
-      strip_prefix = "rules_fuzzing-a8e8945bebf4f2a4618b27f127f9fc7009afacff",
-      sha256 = "fa5eaec2cea152bfb37e4b36aa3bdf7de6aeed62822dfb931179175fa267e53b",
-    )
-
     # ********** rules_python *****************
     http_archive(
       name = "rules_python",  # 2021-05-25T23:42:32Z
@@ -97,5 +85,16 @@ def federation_deps():
       urls = [
           "https://zlib.net/zlib-1.2.11.tar.gz",
           "https://zlib.net/zlib-1.2.11.tar.gz"
+      ],
+    )
+    # ********** rules_fuzzing (pinned to 0.1.3) *****************
+    http_archive(
+      name = "rules_fuzzing",
+      sha256 = "94f25c7a18db0502ace26a3ef7d0a25fd7c195c4e9770ddd1b1ec718e8936091",
+      strip_prefix = "rules_fuzzing-0.1.3",
+      # Use the same URL twice to trick bazel into re-trying if connection fails
+      urls = [
+          "https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip",
+          "https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip"
       ],
     )

--- a/federation_deps.bzl
+++ b/federation_deps.bzl
@@ -5,74 +5,86 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def federation_deps():
     # ********** rules_cc *****************
     http_archive(
-      name = "rules_cc",  # 2021-04-01T09:45:57Z
+      name = "rules_cc",  # 2021-05-14T14:51:14Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/bazelbuild/rules_cc/archive/c612c9581b9e740a49ed4c006edb93912c8ab205.zip",
-           "https://github.com/bazelbuild/rules_cc/archive/c612c9581b9e740a49ed4c006edb93912c8ab205.zip"
+           "https://github.com/bazelbuild/rules_cc/archive/68cb652a71e7e7e2858c50593e5a9e3b94e5b9a9.zip",
+           "https://github.com/bazelbuild/rules_cc/archive/68cb652a71e7e7e2858c50593e5a9e3b94e5b9a9.zip"
       ],
-      strip_prefix = "rules_cc-c612c9581b9e740a49ed4c006edb93912c8ab205",
-      sha256 = "1bef6433ba1a4288b5853dc0ebd6cf436dc1c83cce6e16abf73e7ad1b785def4",
+      strip_prefix = "rules_cc-68cb652a71e7e7e2858c50593e5a9e3b94e5b9a9",
+      sha256 = "1e19e9a3bc3d4ee91d7fcad00653485ee6c798efbbf9588d40b34cbfbded143d",
+    )
+
+    # ********** rules_fuzzing *****************
+    http_archive(
+      name = "rules_fuzzing",  # 2021-05-19T01:47:21Z
+      urls = [
+           # Use the same URL twice to trick bazel into re-trying if connection fails
+           "https://github.com/bazelbuild/rules_fuzzing/archive/a8e8945bebf4f2a4618b27f127f9fc7009afacff.zip",
+           "https://github.com/bazelbuild/rules_fuzzing/archive/a8e8945bebf4f2a4618b27f127f9fc7009afacff.zip"
+      ],
+      strip_prefix = "rules_fuzzing-a8e8945bebf4f2a4618b27f127f9fc7009afacff",
+      sha256 = "fa5eaec2cea152bfb37e4b36aa3bdf7de6aeed62822dfb931179175fa267e53b",
     )
 
     # ********** rules_python *****************
     http_archive(
-      name = "rules_python",  # 2021-04-01T19:21:20Z
+      name = "rules_python",  # 2021-05-25T23:42:32Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/bazelbuild/rules_python/archive/5126cf1bd3d423bbb6aebe14e44546ca2585ea44.zip",
-           "https://github.com/bazelbuild/rules_python/archive/5126cf1bd3d423bbb6aebe14e44546ca2585ea44.zip"
+           "https://github.com/bazelbuild/rules_python/archive/c6970fc44877dbbbce84d17845d9bc797aefe299.zip",
+           "https://github.com/bazelbuild/rules_python/archive/c6970fc44877dbbbce84d17845d9bc797aefe299.zip"
       ],
-      strip_prefix = "rules_python-5126cf1bd3d423bbb6aebe14e44546ca2585ea44",
-      sha256 = "804179a8dced7cb8f14218d6810990391d4d82bb1e1c636a579bbc45ee0e7694",
+      strip_prefix = "rules_python-c6970fc44877dbbbce84d17845d9bc797aefe299",
+      sha256 = "01ce6e66ce46ee2fda606c554f4b69af7a9b2e60410d7561286169e39950c88f",
     )
 
     # ********** com_google_absl *****************
     http_archive(
-      name = "com_google_absl",  # 2021-04-01T22:28:34Z
+      name = "com_google_absl",  # 2021-05-25T20:18:25Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/abseil/abseil-cpp/archive/354030bec37f8d90092245e07323628da50c6996.zip",
-           "https://github.com/abseil/abseil-cpp/archive/354030bec37f8d90092245e07323628da50c6996.zip"
+           "https://github.com/abseil/abseil-cpp/archive/18045c4e32cbe6217224f46261b9e2607d6e723d.zip",
+           "https://github.com/abseil/abseil-cpp/archive/18045c4e32cbe6217224f46261b9e2607d6e723d.zip"
       ],
-      strip_prefix = "abseil-cpp-354030bec37f8d90092245e07323628da50c6996",
-      sha256 = "98a06857490d4cc160d56a7dce1766fb676b74b1244d1a1c36996e3b21890808",
+      strip_prefix = "abseil-cpp-18045c4e32cbe6217224f46261b9e2607d6e723d",
+      sha256 = "0eb45079ef7b7ad939edb4cd66ff1c48f3ea177ff8877cb890db812dabb9cd1c",
     )
 
     # ********** com_google_googletest *****************
     http_archive(
-      name = "com_google_googletest",  # 2021-03-30T04:29:19Z
+      name = "com_google_googletest",  # 2021-05-25T17:34:39Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/google/googletest/archive/6c5c4554ac218a8e19168edc121b1ad232015185.zip",
-           "https://github.com/google/googletest/archive/6c5c4554ac218a8e19168edc121b1ad232015185.zip"
+           "https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip",
+           "https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip"
       ],
-      strip_prefix = "googletest-6c5c4554ac218a8e19168edc121b1ad232015185",
-      sha256 = "4d6bb52c23b6c590fd0f8bea90bed9a1f263c61a1ac0e2d66dadb9213fbe4b1c",
+      strip_prefix = "googletest-a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b",
+      sha256 = "d3d307a240e129bb57da8aae64f3b0099bf1b8efff7249df993b619b8641ec77",
     )
 
     # ********** com_github_google_benchmark *****************
     http_archive(
-      name = "com_github_google_benchmark",  # 2021-03-30T13:43:03Z
+      name = "com_github_google_benchmark",  # 2021-05-21T08:48:20Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/google/benchmark/archive/5e387e7d33a55b8d6b7c5025379b97cc9418fabf.zip",
-           "https://github.com/google/benchmark/archive/5e387e7d33a55b8d6b7c5025379b97cc9418fabf.zip"
+           "https://github.com/google/benchmark/archive/db2de74cc8c34131a6f673e35751935cc1897a0d.zip",
+           "https://github.com/google/benchmark/archive/db2de74cc8c34131a6f673e35751935cc1897a0d.zip"
       ],
-      strip_prefix = "benchmark-5e387e7d33a55b8d6b7c5025379b97cc9418fabf",
-      sha256 = "d37d3fb186bbcc30018962185606869c032e866bc9ad376a6112fbb64fe6935f",
+      strip_prefix = "benchmark-db2de74cc8c34131a6f673e35751935cc1897a0d",
+      sha256 = "0b6380d26b38a7d06a578dfb286e51d804db418feef7f86a2c2af582badbfb31",
     )
 
     # ********** com_github_google_tcmalloc *****************
     http_archive(
-      name = "com_github_google_tcmalloc",  # 2021-04-02T18:56:30Z
+      name = "com_github_google_tcmalloc",  # 2021-05-25T18:44:42Z
       urls = [
            # Use the same URL twice to trick bazel into re-trying if connection fails
-           "https://github.com/google/tcmalloc/archive/5f73843f6daab27d8feb67210597a5e11c2a0486.zip",
-           "https://github.com/google/tcmalloc/archive/5f73843f6daab27d8feb67210597a5e11c2a0486.zip"
+           "https://github.com/google/tcmalloc/archive/bda09979a30886cbe8a6f69dff0c17da03dda54c.zip",
+           "https://github.com/google/tcmalloc/archive/bda09979a30886cbe8a6f69dff0c17da03dda54c.zip"
       ],
-      strip_prefix = "tcmalloc-5f73843f6daab27d8feb67210597a5e11c2a0486",
-      sha256 = "e1d692c92831e791fa80e5eef3b93c118b5dfc9b35ff38b491c688936112c30c",
+      strip_prefix = "tcmalloc-bda09979a30886cbe8a6f69dff0c17da03dda54c",
+      sha256 = "ae2c30267d028a4f46f29040944a89ba88edac4ca440137b7dab69dfcc8d32dc",
     )
 
     # ********** zlib (pinned to 1.2.11) *****************

--- a/head_sync.py
+++ b/head_sync.py
@@ -54,6 +54,7 @@ class GitHubProject(ExternalDependency):
 
 PROJECTS = [
     GitHubProject('rules_cc', 'bazelbuild', 'rules_cc'),
+    GitHubProject('rules_fuzzing', 'bazelbuild', 'rules_fuzzing'),
     GitHubProject('rules_python', 'bazelbuild', 'rules_python'),
     GitHubProject('com_google_absl', 'abseil', 'abseil-cpp'),
     GitHubProject('com_google_googletest', 'google', 'googletest'),

--- a/head_sync.py
+++ b/head_sync.py
@@ -54,7 +54,6 @@ class GitHubProject(ExternalDependency):
 
 PROJECTS = [
     GitHubProject('rules_cc', 'bazelbuild', 'rules_cc'),
-    GitHubProject('rules_fuzzing', 'bazelbuild', 'rules_fuzzing'),
     GitHubProject('rules_python', 'bazelbuild', 'rules_python'),
     GitHubProject('com_google_absl', 'abseil', 'abseil-cpp'),
     GitHubProject('com_google_googletest', 'google', 'googletest'),
@@ -85,5 +84,17 @@ print("      # Use the same URL twice to trick bazel into re-trying if connectio
 print("      urls = [")
 print("          \"https://zlib.net/zlib-1.2.11.tar.gz\",")
 print("          \"https://zlib.net/zlib-1.2.11.tar.gz\"")
+print("      ],")
+print("    )")
+
+print("    # ********** rules_fuzzing (pinned to 0.1.3) *****************")
+print("    http_archive(")
+print("      name = \"rules_fuzzing\",")
+print("      sha256 = \"94f25c7a18db0502ace26a3ef7d0a25fd7c195c4e9770ddd1b1ec718e8936091\",")
+print("      strip_prefix = \"rules_fuzzing-0.1.3\",")
+print("      # Use the same URL twice to trick bazel into re-trying if connection fails")
+print("      urls = [")
+print("          \"https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip\",")
+print("          \"https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.3.zip\"")
 print("      ],")
 print("    )")

--- a/test/WORKSPACE
+++ b/test/WORKSPACE
@@ -6,3 +6,9 @@ local_repository(
 load("@com_google_absl_oss_federation//:federation_deps.bzl", "federation_deps")
 
 federation_deps()
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+rules_fuzzing_dependencies()
+
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+rules_fuzzing_init()


### PR DESCRIPTION
TCMalloc writes its fuzz tests in terms of the rules_fuzzing package,
which broke the daily federation updates starting with
https://github.com/abseil/federation-head/pull/498, following
https://github.com/google/tcmalloc/commit/777b437cb65e48be5d366d6aa2033b4501ae9ebb.